### PR TITLE
Elasticsearch Memory Settings

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -11,13 +11,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install dependencies
-        run: pip3 install ansible ansible-lint yamllint
+        run: pip3 install ansible ansible-lint yamllint molecule
+
+      - name: install roles from galaxy
+        run: ansible-galaxy install elan.opencast_repository
+
+      - name: create lxc container
+        uses: lkiesow/setup-lxc-container@v1
+        with:
+          dist: centos
+          release: 9-Stream
 
       - name: ansible lint
         run: ansible-lint
 
       - name: yamllint
         run: yamllint -c .yamllint .
+
+      - name: run molecule tests
+        run: molecule test

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Role Variables
 --------------
 
 - `opencast_repository_identifiers`
-    - List of repository identifiers to temporarily activate for integration
-	 - Will usually be provided by the [elan.opencast_repository](https://github.com/elan-ev/opencast_repository) role
+  - List of repository identifiers to temporarily activate for integration
+  - Will usually be provided by the [elan.opencast_repository](https://github.com/elan-ev/opencast_repository) role
+- `opencast_elasticsearch_heap_size`
+  - Memory configuration (default: `1g`)
+  - Might make sense to set this to `2g` for larger installations.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+opencast_elasticsearch_heap_size: 1g

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    opencast_version_major: 13
+  tasks:
+    - name: Include opencast_elasticsearch
+      ansible.builtin.include_role:
+        name: opencast_elasticsearch

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: false
+    login_cmd_template: ssh {instance}
+    ansible_connection_options:
+      ansible_connection: ssh
+platforms:
+  - name: test
+lint: |
+  set -e
+  yamllint -c .yamllint .
+  ansible-lint
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check timer is active
+      ansible.builtin.command:  # noqa no-changed-when command-instead-of-module
+        cmd: systemctl is-active elasticsearch.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,14 @@
 ---
-- include_tasks: debian.yml
+- name: Debian specific tasks
+  ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include_tasks: rhel7.yml
+- name: EL7 specific tasks
+  ansible.builtin.include_tasks: rhel7.yml
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version | int == 7
 
-- include_tasks: rhel8.yml
+- name: EL>7 specific tasks
+  ansible.builtin.include_tasks: rhel8.yml
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version | int > 7
 
 - name: Apply log4shell mitigation
@@ -16,6 +19,16 @@
     group: root
     mode: "0644"
   notify: Restart elasticsearch
+
+- name: Adjust Elasticsearch heap size
+  ansible.builtin.replace:
+    path: /etc/elasticsearch/jvm.options
+    regexp: '^-{{ item }}.*'
+    replace: '-{{ item }}{{ opencast_elasticsearch_heap_size }}'
+  notify: Restart elasticsearch
+  loop:
+    - Xms
+    - Xmx
 
 - name: Start and enable elasticsearch service
   ansible.builtin.systemd:


### PR DESCRIPTION
This patch introduces setting memory settings of Elasticsearch via `opencast_elasticsearch_heap_size`.

This patch also adds Molecule tests to ensure the role is not broken.